### PR TITLE
fix: quoting for default trigger value

### DIFF
--- a/src/run.sh
+++ b/src/run.sh
@@ -199,7 +199,7 @@ function submit(){
           # --printshellcmds --keep-going --rerun-incomplete 
           # --keep-remote --restart-times 3 -j 500 --use-singularity 
           # --singularity-args -B {}.format({bindpaths}) --local-cores 24
-          triggers="${7:-'code params software_env input mtime'}"
+          triggers="${7:-"code params software-env input mtime"}"
           rerun="--rerun-triggers $triggers"
           
           SLURM_DIR="$3/logfiles/slurmfiles"


### PR DESCRIPTION
A fix for the incorrect string quote in the `run.sh` bash script