### PR TITLE
Humann profiling

### DIFF
--- a/config/cluster.json
+++ b/config/cluster.json
@@ -40,7 +40,7 @@
         "gres": "lscratch:600"
     }, 
     "derep_bins": {
-        "threads": 32,
+        "threads": 56,
         "mem": "64G",
         "partition": "norm",
         "time": "2-00:00:00",

--- a/config/resources.json
+++ b/config/resources.json
@@ -63,7 +63,7 @@
         }, {
             "name": "humann3_protein_db",
             "to": "/data2/uniref",
-            "from": "/data/OpenOmics/references/metamorph/uniref",
+            "from": "/data/OpenOmics/references/metamorph/uniref/uniref90_filtered",
             "mode": "rw"
         }, {
             "name": "humann3_nuc_db",

--- a/docker/metawrap/Dockerfile
+++ b/docker/metawrap/Dockerfile
@@ -12,7 +12,7 @@ RUN mamba install -y -n metawrap-env -c bioconda spades=3.15.5
 RUN cd /home; git clone https://github.com/rroutsong/metaWRAP.git; chmod -R 777 metaWRAP
 RUN mamba create -n checkm python=3.8
 RUN mamba install -y -n checkm -c bioconda numpy matplotlib pysam hmmer prodigal pplacer fastani samtools bowtie2 trnascan-se gunc prokka gtdbtk=2.3.2
-RUN mamba run -n checkm pip3 install checkm-genome drep
+RUN mamba run -n checkm pip3 install checkm-genome git+https://github.com/OpenOmics/drep.git
 RUN mamba create -n bb3 python=3.7 
 RUN mamba install -y -n bb3 -c biobakery humann
 RUN mkdir /install; cd /install; wget https://carlowood.github.io/which/which-2.21.tar.gz; tar xvf which-2.21.tar.gz

--- a/metamorph
+++ b/metamorph
@@ -161,7 +161,7 @@ def run(sub_args):
     config["options"]["assembler_mode"] = "1" if sub_args.megahit_only else "0"
 
     # Step 4c. Setup humann3 execution mode
-    config["options"]["deep_profile"] = "1" if sub_args.deep_profile else "0"
+    config["options"]["shallow_profile"] = "1" if sub_args.shallow_profile else "0"
 
     # Step 5. Save config to output directory
     with open(os.path.join(sub_args.output, 'config.json'), 'w') as fh:
@@ -397,10 +397,10 @@ def parsed_arguments(name, description):
                                 Default (in prority order):
                                     params, mtime, code, software-env, input
                                            
-          --deep-profile
-                                Turn on the translated blast search of unaligned
-                                reads in humann3. This will increase run time 
-                                significantly. Turns on the protein search for
+          --shallow-profile
+                                Turn off the translated blast search of unaligned
+                                reads in humann3. This will decrease run time 
+                                significantly. Turns off the protein search for
                                 unaligned reads for humann3 taxanomic profiling.
           
         
@@ -595,8 +595,8 @@ def parsed_arguments(name, description):
     # Set humann3 to run translated protein
     # search of unaligned reads
     subparser_run.add_argument(
-        '--deep-profile',
-        dest = 'deep_profile',
+        '--shallow-profile',
+        dest = 'shallow_profile',
         action = 'store_true',
         required = False,
         default = False,

--- a/metamorph
+++ b/metamorph
@@ -160,6 +160,9 @@ def run(sub_args):
     #   modes: 0 - megahit + metaspades assembly
     config["options"]["assembler_mode"] = "1" if sub_args.megahit_only else "0"
 
+    # Step 4c. Setup humann3 execution mode
+    config["options"]["deep_profile"] = "1" if sub_args.deep_profile else "0"
+
     # Step 5. Save config to output directory
     with open(os.path.join(sub_args.output, 'config.json'), 'w') as fh:
         json.dump(config, fh, indent = 4, sort_keys = True)
@@ -279,8 +282,8 @@ def parsed_arguments(name, description):
           $ {2} run [--help] \\
                 [--dry-run] [--job-name JOB_NAME] [--mode {{slurm,local}}] \\
                 [--sif-cache SIF_CACHE] [--singularity-cache SINGULARITY_CACHE] \\
-                [--silent] [--threads THREADS] [--tmp-dir TMP_DIR] \\
-                --input INPUT [INPUT ...] \\
+                [--silent] [--threads THREADS] [--megahit-only] [--deep-profile] \\
+                [--tmp-dir TMP_DIR] --input INPUT [INPUT ...] \\
                 --output OUTPUT
 
         Optional arguments are shown in square brackets above.
@@ -375,6 +378,31 @@ def parsed_arguments(name, description):
                                 recommended setting this vaule to the maximum number 
                                 of CPUs available on the host machine, default: 2.
                                   Example: --threads: 16
+                                           
+          --megahit-only
+                                Use only the megahit assembler for bin assembly.
+                                Turns off the metaspades assembler
+                                Example: --megahit-only
+                                           
+          -t(--triggers) TRIGGER [TRIGGER ...]
+                                Manual control of the snakemake rerun triggers.
+                                Trigger values must be one or more of:
+                                    - mtime
+                                    - code
+                                    - software-env
+                                    - input
+                                    - params
+                                See https://snakemake.readthedocs.io/en/stable/executing/cli.html
+                                for more details about snakemake rerun triggers.
+                                Default (in prority order):
+                                    params, mtime, code, software-env, input
+                                           
+          --deep-profile
+                                Turn on the translated blast search of unaligned
+                                reads in humann3. This will increase run time 
+                                significantly. Turns on the protein search for
+                                unaligned reads for humann3 taxanomic profiling.
+          
         
         {3}{4}Misc Options:{5}
           -h, --help            Show usage information, help message, and exit.
@@ -553,11 +581,8 @@ def parsed_arguments(name, description):
         help = argparse.SUPPRESS
     )
 
-    # Number of threads for the 
-    # pipeline's main proceess
-    # This is only applicable for 
-    # local rules or when running 
-    # in local mode.
+    # Selection of the assemblers used.
+    # Either megahit only or metaspades & megahit
     subparser_run.add_argument(
         '--megahit-only',
         dest = 'megahit_only',
@@ -567,8 +592,22 @@ def parsed_arguments(name, description):
         help = argparse.SUPPRESS
     )
 
-    # Selection of the assemblers used.
-    # Using 
+    # Set humann3 to run translated protein
+    # search of unaligned reads
+    subparser_run.add_argument(
+        '--deep-profile',
+        dest = 'deep_profile',
+        action = 'store_true',
+        required = False,
+        default = False,
+        help = argparse.SUPPRESS
+    )
+
+    # Number of threads for the 
+    # pipeline's main proceess
+    # This is only applicable for 
+    # local rules or when running 
+    # in local mode.
     subparser_run.add_argument(
         '--threads',
         type = int,

--- a/workflow/rules/DNA.smk
+++ b/workflow/rules/DNA.smk
@@ -559,7 +559,7 @@ rule derep_bins:
         DREP_BINS=$(ls {params.bindir}/*/{params.metawrap_dir_name}/*.fa | tr '\\n' ' ')
         NUM_BINS=$(ls 2>/dev/null -Ubad1 -- {params.bindir}/*/{params.metawrap_dir_name}/*.fa | wc -l)
         NUM_CHUNK=$(( echo $NUM_BINS/3 ))
-        NUM_CHUNK=$(echo $NUM_CHUNK | awk '{print int($1+0.5)}')
+        NUM_CHUNK=$(echo $NUM_CHUNK | awk '{{print int($1+0.5)}}')
         mkdir -p {params.outto}
         dRep dereplicate -d \
         -g ${{DREP_BINS}} \

--- a/workflow/rules/DNA.smk
+++ b/workflow/rules/DNA.smk
@@ -449,15 +449,16 @@ rule cumulative_bin_stats:
         done
 
         # generate cumulative statistic report for binning
-        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metabat2_stats}
+        FNs="genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner"
+        echo $FNs > {output.cumulative_metabat2_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
             tail -n+2 $report  >> {output.cumulative_maxbin_stats}
         done
-        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metabat2_stats}
+        echo $FNs > {output.cumulative_metabat2_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
             tail -n+2 $report  >> {output.cumulative_metabat2_stats}
         done
-        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metawrap_stats}
+        echo $FNs > {output.cumulative_metawrap_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
             tail -n+2 $report >> {output.cumulative_metawrap_stats}
         done

--- a/workflow/rules/DNA.smk
+++ b/workflow/rules/DNA.smk
@@ -415,10 +415,14 @@ rule bin_stats:
         metawrap_contigs=$(cat {input.metawrap_bins}/*fa | grep -c "^>")
         echo "SampleID\tmetabat2_bins\tmaxbin2_bins\tmetaWRAP_50_5_bins\tmetabat2_contigs\tmaxbin2_contigs\tmetaWRAP_50_5_contigs" > {output.this_refine_summary}
         echo "{params.sid}\t{params.metabat2_num_bins}\t{params.maxbin_num_bins}\t{params.metawrap_num_bins}\t$metabat2_contigs\t$maxbin_configs\t$metawrap_contigs" >> {output.this_refine_summary}
+        
         # name contigs with SID
         cat {input.maxbin_stats} | sed 's/^bin./{params.sid}_bin./g' > {output.named_stats_maxbin2}
-		cat {input.metabat2_stats} | sed 's/^bin./{params.sid}_bin./g' > {output.named_stats_metabat2}
-		cat {input.metawrap_stats} | sed 's/^bin./{params.sid}_bin./g' > {output.named_stats_metawrap}
+        sed -i '1 s/^.*$/genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner/' {output.named_stats_maxbin2}
+        cat {input.metabat2_stats} | sed 's/^bin./{params.sid}_bin./g' > {output.named_stats_metabat2}
+        sed -i '1 s/^.*$/genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner/' {output.named_stats_metabat2}
+        cat {input.metawrap_stats} | sed 's/^bin./{params.sid}_bin./g' > {output.named_stats_metawrap}
+        sed -i '1 s/^.*$/genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner/' {output.named_stats_metawrap}
         """
 
 
@@ -445,14 +449,17 @@ rule cumulative_bin_stats:
         done
 
         # generate cumulative statistic report for binning
+        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metabat2_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
-            cat $report >> {output.cumulative_maxbin_stats}
+            tail -n+2 $report  >> {output.cumulative_maxbin_stats}
         done
+        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metabat2_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
-            cat $report >> {output.cumulative_metabat2_stats}
+            tail -n+2 $report  >> {output.cumulative_metabat2_stats}
         done
+        echo "genome\tcompleteness\tcontamination\tGC\tlineage\tN50\tsize\tbinner" > {output.cumulative_metawrap_stats}
         for report in `ls {params.refine_dir}/*/named_maxbin2_bins.stats`; do
-            cat $report >> {output.cumulative_metawrap_stats}
+            tail -n+2 $report >> {output.cumulative_metawrap_stats}
         done
 
         if $(wc -l < {output.cumulative_bin_summary}) -le 1; then
@@ -460,6 +467,27 @@ rule cumulative_bin_stats:
             exit 1
         fi
         """
+
+rule prep_genome_info:
+    input:
+        expand(join(top_refine_dir, "{name}", "named_metawrap_bins.stats"), name=samples),
+    output:
+        join(top_refine_dir, "genomeInfo.csv")
+    localrule: True
+    run:
+        from csv import DictReader, DictWriter
+        combined_info = []
+        for sample_info in input:
+            with open(sample_info, 'r') as this_csv:
+                reader = csv.DictReader(this_csv, delimiter="\t")
+                for row in reader:
+                    row['genome'] = row['genome'] + '.fa'
+                    combined_info.append(row)
+        
+        with open(output[0], 'w') as genome_info_out:
+            wrt = DictWriter(genome_info_out, list(row.keys()), delimter="\t")
+            wrt.writeheader()
+            wrt.writerows(combined_info)
 
 
 rule derep_bins:
@@ -469,15 +497,16 @@ rule derep_bins:
         of average nucleotide identity.
 
         @Input:
-            maxbin2 ssembly bins, contigs, stat summaries
-            metabat2 ssembly bins, contigs, stat summaries
-            metawrap ssembly bins, contigs, stat summaries
+            maxbin2 assembly bins, contigs, stat summaries
+            metabat2 assembly bins, contigs, stat summaries
+            metawrap assembly bins, contigs, stat summaries
 
         @Output:
             directory of consensus ensemble bins (deterministic output)
     """
     input:
         bins                        = expand(join(top_binning_dir, "{name}", "{name}_BINNING_COMPLETE"), name=samples),
+        ginfo                       = join(top_refine_dir, "genomeInfo.csv"),
     output:
         derep_genome_info           = join(top_refine_dir, "dRep", "data_tables", "Widb.csv"),
         derep_winning_figure        = join(top_refine_dir, "dRep", "figures", "Winning_genomes.pdf"),
@@ -493,15 +522,19 @@ rule derep_bins:
         outto                       = join(top_refine_dir, "dRep"),
         metawrap_dir_name           = "metawrap_50_5_bins",
         # -l LENGTH: Minimum genome length (default: 50000)
-        minimum_genome_length       = "1000",
+        minimum_genome_length       = "10000",
         # -pa[--P_ani] P_ANI: ANI threshold to form primary (MASH) clusters (default: 0.9)
         ani_primary_threshold       = "0.9",
         # -sa[--S_ani] S_ANI: ANI threshold to form secondary clusters (default: 0.95)
         ani_secondary_threshold     = "0.95",
         # -nc[--cov_thresh] COV_THRESH: Minmum level of overlap between genomes when doing secondary comparisons (default: 0.1)
-        min_overlap                 = "0.1",
+        min_overlap                 = "0.3",
         # -cm[--coverage_method] {total,larger}  {total,larger}: Method to calculate coverage of an alignment
-        coverage_method             = 'larger'
+        coverage_method             = 'larger',
+        # -comp COMPLETENESS, --completeness COMPLETENESS: Minimum genome completeness (default: 75)
+        completeness                = "50",
+        # --S_algorithm {fastANI,ANImf,ANIn,goANI,gANI}: Algorithm for secondary clustering comaprisons:
+        second_cluster_algo         = "fastANI"
     shell:
         """
         # tmp directory creation and destruction
@@ -510,11 +543,14 @@ rule derep_bins:
         export TMPDIR=${{tmp}}
         trap 'rm -rf "${{tmp}}"' EXIT
 
-        # activate conda environment, initialize checkm
+        # activate conda environment, initialize checkm, check deps
         . /opt/conda/etc/profile.d/conda.sh && conda activate checkm
         checkm data setRoot /data2/CHECKM_DB
         export CHECKM_DATA_PATH="/data2/CHECKM_DB"
         dRep check_dependencies
+
+        # create checkm completeness and contamination info file
+
 
         # run drep
         DREP_BINS=$(ls {params.bindir}/*/{params.metawrap_dir_name}/*.fa | tr '\\n' ' ')
@@ -527,6 +563,10 @@ rule derep_bins:
         -sa {params.ani_secondary_threshold} \
         -nc {params.min_overlap} \
         -cm {params.coverage_method} \
+        --genomeInfo {input.ginfo} \
+        --S_algorithm {params.second_cluster_algo} \
+        -comp {params.completeness} \
+        -con {params.} \
         {params.outto}
         """
 

--- a/workflow/rules/RNA.smk
+++ b/workflow/rules/RNA.smk
@@ -108,7 +108,7 @@ rule rna_humann_classify:
         chocophlan_db       = "/data2/chocophlan",  # from <root>/config/resources.json
         util_map_db         = "/data2/um",          # from <root>/config/resources.json
         metaphlan_db        = "/data2/metaphlan",   # from <root>/config/resources.json
-        deep_mode           = "\\\n        --bypass-translated-search" if humann_deep_mode else "",
+        deep_mode           = "\\\n        --bypass-translated-search" if not config["options"]["shallow_profile"] else "",
     threads: int(cluster["rna_humann_classify"].get('threads', default_threads)),
     containerized: metawrap_container,
     shell:

--- a/workflow/rules/RNA.smk
+++ b/workflow/rules/RNA.smk
@@ -116,16 +116,9 @@ rule rna_humann_classify:
         tmp=$(mktemp -d -p "{params.tmp_safe_dir}")
         trap 'rm -rf "{params.tmp_safe_dir}"' EXIT
 
-        # human configuration
+        # human/metaphlan configuration
         humann_config --print > {output.humann_config}
-
-        # metaphlan configuration
         export DEFAULT_DB_FOLDER={params.metaphlan_db}
-        
-        # mapping execution
-        
-        # old method signature 
-        #   --metaphlan-options "--bowtie2db {params.metaphlan_db} --nproc {threads}"
 
         cat {input.R1} {input.R2} > {params.tmpread}
 		humann \
@@ -133,7 +126,7 @@ rule rna_humann_classify:
         --input {params.tmpread} \
         --remove-temp-output \
         --input-format fastq.gz \
-        --metaphlan-options "--bowtie2db {params.metaphlan_db}" \
+        --metaphlan-options "--bowtie2db {params.metaphlan_db} --nproc {threads}" \
         --output-basename {params.sid} \
         --log-level DEBUG \
         --o-log {output.humann_log} \

--- a/workflow/rules/RNA.smk
+++ b/workflow/rules/RNA.smk
@@ -20,6 +20,8 @@ pairedness                          = list(range(1, config['project']['nends']+1
 top_readqc_dir_rna                  = join(workpath, config['project']['id'], "metawrap_read_qc_RNA")
 top_trim_dir_rna                    = join(workpath, config['project']['id'], "trimmed_reads_RNA")
 top_map_dir_rna                     = join(workpath, config['project']['id'], "mapping_RNA")
+humann_deep_mode                    = True if "deep_profile" in config["options"] and \
+                                      bool(int(config["options"]["deep_profile"])) else False
 
 
 rule rna_read_qc:
@@ -106,6 +108,7 @@ rule rna_humann_classify:
         chocophlan_db       = "/data2/chocophlan",  # from <root>/config/resources.json
         util_map_db         = "/data2/um",          # from <root>/config/resources.json
         metaphlan_db        = "/data2/metaphlan",   # from <root>/config/resources.json
+        deep_mode           = "\\\n        --bypass-translated-search" if humann_deep_mode else "",
     threads: int(cluster["rna_humann_classify"].get('threads', default_threads)),
     containerized: metawrap_container,
     shell:
@@ -125,7 +128,7 @@ rule rna_humann_classify:
         --threads {threads} \
         --input {params.tmpread} \
         --remove-temp-output \
-        --input-format fastq.gz \
+        --input-format fastq.gz {params.deep_mode} \
         --metaphlan-options "--bowtie2db {params.metaphlan_db} --nproc {threads}" \
         --output-basename {params.sid} \
         --log-level DEBUG \


### PR DESCRIPTION
Changes related to profiling of human3, dRep, and MASH.

- Pass threads to bowtie
- capture metawrap + checkm outputs, reformat, and inject into dRep
- added flag for turning on deep profiling mode (humann3)
- tweaked resource allocation for profiling related rules