### PR TITLE
Fix: Updating regex to work with SRR/SRA indentifers.

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -457,7 +457,7 @@ def add_sample_metadata(input_files, config, group_key='samples'):
     config[group_key] = []
     for file in input_files:
         # Split sample name on file extension
-        sample = re.split(r'[\S]R[12]', os.path.basename(file))[0]
+        sample = re.split(r'\_R[12]\.fastq\.gz$', os.path.basename(file))[0]
         if sample not in added:
             # Only add PE sample information once
             added.append(sample)


### PR DESCRIPTION
This fixes an issue that was observed when the base name of the sample contains the substring R1/R2. This happened while processing some samples from SRA that were downloaded with fastq-dump. One of the samples started with `SRR123...` which contains the sub string R1.